### PR TITLE
Encode certificate base64, to avoid problems when receiving the diagnostic protocol.

### DIFF
--- a/dss-document/src/main/java/eu/europa/esig/dss/validation/DiagnosticDataBuilder.java
+++ b/dss-document/src/main/java/eu/europa/esig/dss/validation/DiagnosticDataBuilder.java
@@ -806,7 +806,7 @@ public class DiagnosticDataBuilder {
 		final XmlCertificate xmlCert = new XmlCertificate();
 
 		xmlCert.setId(certToken.getDSSIdAsString());
-		xmlCert.setBase64Encoded(certToken.getEncoded());
+                xmlCert.setBase64Encoded(Utils.toBase64(certToken.getEncoded()).getBytes());
 
 		xmlCert.getSubjectDistinguishedName().add(getXmlDistinguishedName(X500Principal.CANONICAL, certToken.getSubjectX500Principal()));
 		xmlCert.getSubjectDistinguishedName().add(getXmlDistinguishedName(X500Principal.RFC2253, certToken.getSubjectX500Principal()));


### PR DESCRIPTION
Base64 encode certificate to avoid problems when receiving the diagnostic protocol.